### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kengggg/kengggg.github.io/security/code-scanning/7](https://github.com/kengggg/kengggg.github.io/security/code-scanning/7)

In general, the fix is to declare an explicit `permissions` block that grants only the minimal access needed for the workflow. Since this workflow only checks out the code and builds the Jekyll site, it does not need to write to the repository or interact with issues, PRs, or workflows, so `contents: read` at minimum is sufficient.

The best way to fix this specific workflow without changing functionality is to add a `permissions:` section at the workflow root (top level, alongside `name:` and `on:`). This will apply to all jobs in the workflow, including `build`. Set `contents: read` so that actions like `actions/checkout` can read the repository contents, while removing any unnecessary write capabilities from the `GITHUB_TOKEN`. No imports or additional methods are required, since this is only a YAML configuration change.

Concretely, in `.github/workflows/jekyll.yml`, insert the `permissions` block after the `on:` section (e.g., after line 4 and before `jobs:`), with the following content:

```yaml
permissions:
  contents: read
```

This preserves existing behavior (the build continues to run as before) while constraining token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
