### PR TITLE
Update Gemfile dependencies to latest versions and add csv gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '4.2.1'
-gem 'jekyll-feed'
-gem 'kramdown', ">= 2.3.0"
-gem "webrick", "~> 1.8"
+gem 'jekyll', '4.4.1'
+gem 'jekyll-feed', '0.17.0'
+gem 'kramdown', '2.5.1'
+gem "webrick", "~> 1.9"
+gem "csv"
 
 group :jekyll_plugins do
-  gem 'jekyll-paginate'
-  gem 'jekyll-sitemap'
+  gem 'jekyll-paginate', '1.1.0'
+  gem 'jekyll-sitemap', '1.4.0'
 end


### PR DESCRIPTION
- jekyll: 4.2.1 → 4.4.1
- jekyll-feed: add explicit version 0.17.0
- kramdown: >= 2.3.0 → 2.5.1
- webrick: ~> 1.8 → ~> 1.9
- jekyll-paginate: add explicit version 1.1.0
- jekyll-sitemap: add explicit version 1.4.0
- Add csv gem for Ruby 3.4+ compatibility