### PR TITLE
Fix Sass deprecation warnings for Dart Sass 2.0/3.0 compatibility

### DIFF
--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // - - - - - - - - - - - - - - - - - -
 
 // Basics
@@ -226,8 +228,8 @@ a {
 	}
 
 	&:hover {
-		background: adjust-hue($accent-color,15%);
-		border-color: adjust-hue($accent-color,15%);
+		background: color.adjust($accent-color, $hue: 15deg);
+		border-color: color.adjust($accent-color, $hue: 15deg);
 		color: $background-color;
 	}
 

--- a/_sass/_includes/_blog.scss
+++ b/_sass/_includes/_blog.scss
@@ -126,10 +126,10 @@
 
 .pagination__prev {
 	float: left;
-	padding-right: $grid-spacing/2;
+	padding-right: calc($grid-spacing / 2);
 }
 
 .pagination__next {
 	float: right;
-	padding-left: $grid-spacing/2;
+	padding-left: calc($grid-spacing / 2);
 }

--- a/_sass/_includes/_contact-form.scss
+++ b/_sass/_includes/_contact-form.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // - - - - - - - - - - - - - - - - - -
 
 // Contact form
@@ -103,16 +105,16 @@
 }
 
 ::-webkit-input-placeholder {
-	color: lighten($text-light-color,15%);
+	color: color.adjust($text-light-color, $lightness: 15%);
 }
 ::-moz-placeholder {
-	color: lighten($text-light-color,15%);
+	color: color.adjust($text-light-color, $lightness: 15%);
 }
 :-ms-input-placeholder {
-	color: lighten($text-light-color,15%);
+	color: color.adjust($text-light-color, $lightness: 15%);
 }
 :-moz-placeholder {
-	color: lighten($text-light-color,15%);
+	color: color.adjust($text-light-color, $lightness: 15%);
 }
 
 .contact-form__textarea {

--- a/_sass/_includes/_gallery.scss
+++ b/_sass/_includes/_gallery.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // - - - - - - - - - - - - - - - - - -
 
 // Gallery
@@ -103,7 +105,7 @@
 		}
 
 		&:hover {
-			background: darken($text-light-color, 10%);
+			background: color.adjust($text-light-color, $lightness: -10%);
 		}
 
 		&.carousel__dot--active {


### PR DESCRIPTION
- Replace deprecated adjust-hue() with color.adjust($hue:) in _basic.scss
- Replace deprecated darken() with color.adjust($lightness:) in _gallery.scss
- Replace deprecated lighten() with color.adjust($lightness:) in _contact-form.scss
- Replace slash division with calc() in _blog.scss
- Add @use "sass:color" to files using color functions

These changes fix deprecation warnings that will become errors in:
- Dart Sass 2.0.0: slash division
- Dart Sass 3.0.0: global color functions