### PR TITLE
Fixing date comparison bug.

### DIFF
--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -10,7 +10,7 @@ export async function GET(context) {
     description: SITE_DESCRIPTION,
     site: context.site,
     items: posts
-      .sort((a, b) => new Date(b.data.date) - new Date(a.data.date))
+      .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
       .map((post) => ({
         title: post.data.title,
         pubDate: post.data.date,


### PR DESCRIPTION
Use explicit .getTime() for date comparison instead of relying on implicit type coercion when sorting posts. This is consistent with the pattern used in index.astro and [page].astro.