### PR TITLE
Refactor blog pagination into reusable utilities

### DIFF
--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -1,38 +1,24 @@
 ---
-import type { GetStaticPaths, Page } from 'astro';
-import { getCollection } from 'astro:content';
+import type { GetStaticPaths } from 'astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPostCard from '../../components/BlogPostCard.astro';
 import { POSTS_PER_PAGE } from '../../consts';
+import {
+  buildPaginationPaths,
+  fetchPublishedPosts,
+  type BlogEntry,
+  sortPostsByDate,
+} from '../../utils/posts';
 
-export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const allPosts = await getCollection('blog', ({ data }) => !data.draft);
-  const sortedPosts = allPosts.sort((a, b) =>
-    new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
-  );
+export const getStaticPaths: GetStaticPaths = async () => {
+  const publishedPosts = await fetchPublishedPosts();
+  const sortedPosts = sortPostsByDate(publishedPosts);
 
-  // Generate pages starting from page 2 (page 1 is handled by index.astro)
-  const paths = [];
-  const totalPages = Math.ceil(sortedPosts.length / POSTS_PER_PAGE);
-
-  for (let i = 2; i <= totalPages; i++) {
-    const start = (i - 1) * POSTS_PER_PAGE;
-    const end = start + POSTS_PER_PAGE;
-    paths.push({
-      params: { page: String(i) },
-      props: {
-        posts: sortedPosts.slice(start, end),
-        currentPage: i,
-        totalPages,
-      },
-    });
-  }
-
-  return paths;
+  return buildPaginationPaths(sortedPosts, POSTS_PER_PAGE);
 };
 
 interface Props {
-  posts: any[];
+  posts: BlogEntry[];
   currentPage: number;
   totalPages: number;
 }

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -1,21 +1,20 @@
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
-import { SITE_TITLE, SITE_DESCRIPTION, SITE_URL } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { fetchPublishedPosts, sortPostsByDate } from '../utils/posts';
 
 export async function GET(context) {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  const posts = await fetchPublishedPosts();
+  const sortedPosts = sortPostsByDate(posts);
 
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site,
-    items: posts
-      .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-      .map((post) => ({
-        title: post.data.title,
-        pubDate: post.data.date,
-        description: post.data.excerpt || '',
-        link: `/blog/${post.slug}/`,
-      })),
+    items: sortedPosts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.excerpt || '',
+      link: `/blog/${post.slug}/`,
+    })),
   });
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,18 +1,12 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import BlogPostCard from '../components/BlogPostCard.astro';
 import { POSTS_PER_PAGE } from '../consts';
+import { fetchPublishedPosts, paginatePosts, sortPostsByDate } from '../utils/posts';
 
-// Get all blog posts, filter out drafts, and sort by date
-const allPosts = await getCollection('blog', ({ data }) => !data.draft);
-const sortedPosts = allPosts.sort((a, b) =>
-  new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
-);
-
-// Pagination - first page
-const posts = sortedPosts.slice(0, POSTS_PER_PAGE);
-const totalPages = Math.ceil(sortedPosts.length / POSTS_PER_PAGE);
+const publishedPosts = await fetchPublishedPosts();
+const sortedPosts = sortPostsByDate(publishedPosts);
+const { posts, totalPages } = paginatePosts(sortedPosts, POSTS_PER_PAGE, 1);
 const hasNextPage = totalPages > 1;
 ---
 

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,59 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export type BlogEntry = CollectionEntry<'blog'>;
+
+export async function fetchPublishedPosts(): Promise<BlogEntry[]> {
+  return getCollection('blog', ({ data }) => !data.draft);
+}
+
+export function sortPostsByDate(posts: BlogEntry[]): BlogEntry[] {
+  return [...posts].sort(
+    (first, second) =>
+      new Date(second.data.date).getTime() - new Date(first.data.date).getTime()
+  );
+}
+
+export function paginatePosts(
+  posts: BlogEntry[],
+  postsPerPage: number,
+  page = 1
+): { posts: BlogEntry[]; totalPages: number; currentPage: number } {
+  const totalPages = Math.max(1, Math.ceil(posts.length / postsPerPage));
+  const currentPage = Math.min(Math.max(page, 1), totalPages);
+  const startIndex = (currentPage - 1) * postsPerPage;
+  const endIndex = startIndex + postsPerPage;
+
+  return {
+    posts: posts.slice(startIndex, endIndex),
+    totalPages,
+    currentPage,
+  };
+}
+
+export function buildPaginationPaths(
+  posts: BlogEntry[],
+  postsPerPage: number,
+  startingPage = 2
+) {
+  const sortedPosts = sortPostsByDate(posts);
+  const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
+  const paths = [] as Array<{
+    params: { page: string };
+    props: { posts: BlogEntry[]; currentPage: number; totalPages: number };
+  }>;
+
+  for (let page = startingPage; page <= totalPages; page++) {
+    const { posts: pagePosts } = paginatePosts(sortedPosts, postsPerPage, page);
+
+    paths.push({
+      params: { page: String(page) },
+      props: {
+        posts: pagePosts,
+        currentPage: page,
+        totalPages,
+      },
+    });
+  }
+
+  return paths;
+}


### PR DESCRIPTION
## Summary
- add shared blog utility module for fetching, sorting, and paginating published posts
- update index page, paginated archive, and RSS feed to consume the new helpers and improved typing

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b74ee46bc8320bf2d9140e23998bf)